### PR TITLE
리팩토링: 컨트롤러 이름 변경

### DIFF
--- a/src/main/java/com/been/onlinestore/controller/CommonApiController.java
+++ b/src/main/java/com/been/onlinestore/controller/CommonApiController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/common")
 @RestController
-public class CommonController {
+public class CommonApiController {
 
     @PutMapping("/info")
     public ResponseEntity<?> updateUserInfo() {

--- a/src/main/java/com/been/onlinestore/controller/HomeApiController.java
+++ b/src/main/java/com/been/onlinestore/controller/HomeApiController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api")
 @RestController
-public class ApiController {
+public class HomeApiController {
 
     @PostMapping("/sign-up")
     public ResponseEntity<?> signUp() {

--- a/src/test/java/com/been/onlinestore/controller/CommonApiControllerTest.java
+++ b/src/test/java/com/been/onlinestore/controller/CommonApiControllerTest.java
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Disabled("구현 전")
 @DisplayName("API 컨트롤러 - 회원 (공통)")
 @Import(SecurityConfig.class)
-@WebMvcTest(CommonController.class)
-class CommonControllerTest {
+@WebMvcTest(CommonApiController.class)
+class CommonApiControllerTest {
 
     @Autowired private MockMvc mvc;
     @Autowired private ObjectMapper mapper;

--- a/src/test/java/com/been/onlinestore/controller/HomeApiControllerTest.java
+++ b/src/test/java/com/been/onlinestore/controller/HomeApiControllerTest.java
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Disabled("구현 전")
 @DisplayName("API 컨트롤러 - 권한 필요 없음")
 @Import(SecurityConfig.class)
-@WebMvcTest(ApiController.class)
-class ApiControllerTest {
+@WebMvcTest(HomeApiController.class)
+class HomeApiControllerTest {
 
     @Autowired private MockMvc mvc;
     @Autowired private ObjectMapper mapper;


### PR DESCRIPTION
모든 API 컨트롤러의 이름에 Api를 명시하고,
모든 권한이 공통으로 사용하는 컨트롤러는 `Common`, 인증 없이 사용할 수 있는 컨트롤러는 `Home`을 붙인다.

This closes #38 