### PR TITLE
주문 상품 서비스 구현

### DIFF
--- a/src/main/java/com/been/onlinestore/domain/Delivery.java
+++ b/src/main/java/com/been/onlinestore/domain/Delivery.java
@@ -16,6 +16,8 @@ import javax.persistence.Id;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import static java.time.LocalDateTime.now;
+
 @Getter
 @ToString(callSuper = true)
 @Entity
@@ -47,6 +49,28 @@ public class Delivery {
 
     public static Delivery of(DeliveryStatus deliveryStatus, int deliveryFee, LocalDateTime deliveredAt) {
         return new Delivery(deliveryStatus, deliveryFee, deliveredAt);
+    }
+
+    public void startPreparing() {
+        if (this.deliveryStatus != DeliveryStatus.ACCEPT) {
+            throw new IllegalArgumentException("상품 준비 단계로 넘어갈 수 없습니다. 현재 배송 상태 = " + this.deliveryStatus.getDescription());
+        }
+        this.deliveryStatus = DeliveryStatus.PREPARING;
+    }
+
+    public void startDelivery() {
+        if (this.deliveryStatus != DeliveryStatus.PREPARING) {
+            throw new IllegalArgumentException("배송을 시작할 수 없습니다. 현재 배송 상태 = " + this.deliveryStatus.getDescription());
+        }
+        this.deliveryStatus = DeliveryStatus.DELIVERING;
+    }
+
+    public void completeDelivery() {
+        if (this.deliveryStatus != DeliveryStatus.DELIVERING) {
+            throw new IllegalArgumentException("배송 중이 아닙니다. 현재 배송 상태 = " + this.deliveryStatus.getDescription());
+        }
+        this.deliveryStatus = DeliveryStatus.FINAL_DELIVERY;
+        this.deliveredAt = now();
     }
 
     @Override

--- a/src/main/java/com/been/onlinestore/domain/OrderProduct.java
+++ b/src/main/java/com/been/onlinestore/domain/OrderProduct.java
@@ -80,6 +80,18 @@ public class OrderProduct {
         product.addStock(this.quantity);
     }
 
+    public void startPreparing() {
+        this.getDelivery().startPreparing();
+    }
+
+    public void startDelivery() {
+        this.getDelivery().startDelivery();
+    }
+
+    public void completeDelivery() {
+        this.getDelivery().completeDelivery();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/been/onlinestore/domain/constant/DeliveryStatus.java
+++ b/src/main/java/com/been/onlinestore/domain/constant/DeliveryStatus.java
@@ -3,7 +3,7 @@ package com.been.onlinestore.domain.constant;
 public enum DeliveryStatus {
 
     ACCEPT("결제 완료"),
-    INSTRUCT("상품 준비중"),
+    PREPARING("상품 준비중"),
     DELIVERING("배송 중"),
     FINAL_DELIVERY("배송 완료");
 

--- a/src/main/java/com/been/onlinestore/repository/OrderProductRepository.java
+++ b/src/main/java/com/been/onlinestore/repository/OrderProductRepository.java
@@ -2,6 +2,16 @@ package com.been.onlinestore.repository;
 
 import com.been.onlinestore.domain.OrderProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface OrderProductRepository extends JpaRepository<OrderProduct, Long> {
+
+    @Query("select op from OrderProduct op " +
+            "join fetch op.delivery d " +
+            "join fetch op.product p " +
+            "where op.id in :orderProductIds and p.seller.id = :sellerId")
+    List<OrderProduct> findAllByIdAndSellerId(@Param("orderProductIds") List<Long> orderProductIds, @Param("sellerId") Long sellerId);
 }

--- a/src/main/java/com/been/onlinestore/service/OrderProductService.java
+++ b/src/main/java/com/been/onlinestore/service/OrderProductService.java
@@ -1,0 +1,32 @@
+package com.been.onlinestore.service;
+
+import com.been.onlinestore.domain.OrderProduct;
+import com.been.onlinestore.repository.OrderProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class OrderProductService {
+
+    private final OrderProductRepository orderProductRepository;
+
+    public void startPreparing(List<Long> orderProductIds, Long sellerId) {
+        List<OrderProduct> orderProducts = orderProductRepository.findAllByIdAndSellerId(orderProductIds, sellerId);
+        orderProducts.forEach(OrderProduct::startPreparing);
+    }
+
+    public void startDelivery(List<Long> orderProductIds, Long sellerId) {
+        List<OrderProduct> orderProducts = orderProductRepository.findAllByIdAndSellerId(orderProductIds, sellerId);
+        orderProducts.forEach(OrderProduct::startDelivery);
+    }
+
+    public void completeDelivery(List<Long> orderProductIds, Long sellerId) {
+        List<OrderProduct> orderProducts = orderProductRepository.findAllByIdAndSellerId(orderProductIds, sellerId);
+        orderProducts.forEach(OrderProduct::completeDelivery);
+    }
+}

--- a/src/test/java/com/been/onlinestore/domain/DeliveryTest.java
+++ b/src/test/java/com/been/onlinestore/domain/DeliveryTest.java
@@ -1,0 +1,61 @@
+package com.been.onlinestore.domain;
+
+import com.been.onlinestore.domain.constant.DeliveryStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DeliveryTest {
+
+    @DisplayName("배송 상태가 ACCEPT일 때만 상품 준비를 시작할 수 있다.")
+    @Test
+    void startInstruct() {
+        Delivery deliveryAccept = Delivery.of(DeliveryStatus.ACCEPT, 3000, LocalDateTime.now());
+        Delivery deliveryInstruct = Delivery.of(DeliveryStatus.PREPARING, 3000, LocalDateTime.now());
+        Delivery deliveryDelivering = Delivery.of(DeliveryStatus.DELIVERING, 3000, LocalDateTime.now());
+        Delivery deliveryFinalDelivery = Delivery.of(DeliveryStatus.FINAL_DELIVERY, 3000, LocalDateTime.now());
+
+        deliveryAccept.startPreparing();
+
+        assertThat(deliveryAccept.getDeliveryStatus()).isEqualTo(DeliveryStatus.PREPARING);
+        assertThatThrownBy(deliveryInstruct::startPreparing).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(deliveryDelivering::startPreparing).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(deliveryFinalDelivery::startPreparing).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("배송 상태가 INSTRUCT일 때만 배송을 시작할 수 있다.")
+    @Test
+    void startDelivery() {
+        Delivery deliveryAccept = Delivery.of(DeliveryStatus.ACCEPT, 3000, LocalDateTime.now());
+        Delivery deliveryInstruct = Delivery.of(DeliveryStatus.PREPARING, 3000, LocalDateTime.now());
+        Delivery deliveryDelivering = Delivery.of(DeliveryStatus.DELIVERING, 3000, LocalDateTime.now());
+        Delivery deliveryFinalDelivery = Delivery.of(DeliveryStatus.FINAL_DELIVERY, 3000, LocalDateTime.now());
+
+        deliveryInstruct.startDelivery();
+
+        assertThatThrownBy(deliveryAccept::startDelivery).isInstanceOf(IllegalArgumentException.class);
+        assertThat(deliveryInstruct.getDeliveryStatus()).isEqualTo(DeliveryStatus.DELIVERING);
+        assertThatThrownBy(deliveryDelivering::startDelivery).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(deliveryFinalDelivery::startDelivery).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("배송 상태가 DELIVERING일 때만 배송을 완료할 수 있다.")
+    @Test
+    void completeDelivery() {
+        Delivery deliveryAccept = Delivery.of(DeliveryStatus.ACCEPT, 3000, LocalDateTime.now());
+        Delivery deliveryInstruct = Delivery.of(DeliveryStatus.PREPARING, 3000, LocalDateTime.now());
+        Delivery deliveryDelivering = Delivery.of(DeliveryStatus.DELIVERING, 3000, LocalDateTime.now());
+        Delivery deliveryFinalDelivery = Delivery.of(DeliveryStatus.FINAL_DELIVERY, 3000, LocalDateTime.now());
+
+        deliveryDelivering.completeDelivery();
+
+        assertThatThrownBy(deliveryAccept::completeDelivery).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(deliveryInstruct::completeDelivery).isInstanceOf(IllegalArgumentException.class);
+        assertThat(deliveryDelivering.getDeliveryStatus()).isEqualTo(DeliveryStatus.FINAL_DELIVERY);
+        assertThatThrownBy(deliveryFinalDelivery::completeDelivery).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/been/onlinestore/service/OrderProductServiceTest.java
+++ b/src/test/java/com/been/onlinestore/service/OrderProductServiceTest.java
@@ -1,0 +1,73 @@
+package com.been.onlinestore.service;
+
+import com.been.onlinestore.domain.constant.DeliveryStatus;
+import com.been.onlinestore.repository.OrderProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.been.onlinestore.util.OrderTestDataUtil.createOrderProduct;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 주문 상품")
+@ExtendWith(MockitoExtension.class)
+class OrderProductServiceTest {
+
+    @Mock private OrderProductRepository orderProductRepository;
+
+    @InjectMocks private OrderProductService sut;
+
+    @DisplayName("[판매자] 주문 상품의 상품 준비를 시작한다.")
+    @Test
+    void test_startPreparing() {
+        //Given
+        long orderProductId = 1L;
+        long sellerId = 1L;
+        List<Long> orderProductIds = List.of(orderProductId);
+        given(orderProductRepository.findAllByIdAndSellerId(orderProductIds, sellerId)).willReturn(List.of(createOrderProduct(orderProductId, DeliveryStatus.ACCEPT)));
+
+        //When
+        sut.startPreparing(orderProductIds, sellerId);
+
+        //Then
+        then(orderProductRepository).should().findAllByIdAndSellerId(orderProductIds, sellerId);
+    }
+
+    @DisplayName("[판매자] 주문 상품의 배송을 시작한다.")
+    @Test
+    void test_startDelivery() {
+        //Given
+        long orderProductId = 1L;
+        long sellerId = 1L;
+        List<Long> orderProductIds = List.of(orderProductId);
+        given(orderProductRepository.findAllByIdAndSellerId(orderProductIds, sellerId)).willReturn(List.of(createOrderProduct(orderProductId, DeliveryStatus.PREPARING)));
+
+        //When
+        sut.startDelivery(orderProductIds, sellerId);
+
+        //Then
+        then(orderProductRepository).should().findAllByIdAndSellerId(orderProductIds, sellerId);
+    }
+
+    @DisplayName("[판매자] 주문 상품의 배송을 완료한다.")
+    @Test
+    void test_completeDelivery() {
+        //Given
+        long orderProductId = 1L;
+        long sellerId = 1L;
+        List<Long> orderProductIds = List.of(orderProductId);
+        given(orderProductRepository.findAllByIdAndSellerId(orderProductIds, sellerId)).willReturn(List.of(createOrderProduct(orderProductId, DeliveryStatus.DELIVERING)));
+
+        //When
+        sut.completeDelivery(orderProductIds, sellerId);
+
+        //Then
+        then(orderProductRepository).should().findAllByIdAndSellerId(orderProductIds, sellerId);
+    }
+}

--- a/src/test/java/com/been/onlinestore/util/OrderTestDataUtil.java
+++ b/src/test/java/com/been/onlinestore/util/OrderTestDataUtil.java
@@ -1,7 +1,10 @@
 package com.been.onlinestore.util;
 
+import com.been.onlinestore.domain.Delivery;
 import com.been.onlinestore.domain.DeliveryRequest;
 import com.been.onlinestore.domain.Order;
+import com.been.onlinestore.domain.OrderProduct;
+import com.been.onlinestore.domain.constant.DeliveryStatus;
 import com.been.onlinestore.domain.constant.OrderStatus;
 import com.been.onlinestore.dto.DeliveryRequestDto;
 import com.been.onlinestore.dto.OrderDto;
@@ -10,6 +13,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
+import static com.been.onlinestore.util.ProductTestDataUtil.createProduct;
 import static com.been.onlinestore.util.UserTestDataUtil.createUser;
 import static java.time.LocalDateTime.now;
 
@@ -37,5 +41,20 @@ public class OrderTestDataUtil {
                 now(),
                 now()
         );
+    }
+
+    public static OrderProduct createOrderProduct(Long id) {
+        return createOrderProduct(id, DeliveryStatus.ACCEPT);
+    }
+
+    public static OrderProduct createOrderProduct(Long id, DeliveryStatus deliveryStatus) {
+        OrderProduct orderProduct = OrderProduct.of(
+                null,
+                createProduct(1L),
+                Delivery.of(deliveryStatus, 3000, now()),
+                10
+        );
+        ReflectionTestUtils.setField(orderProduct, "id", id);
+        return orderProduct;
     }
 }


### PR DESCRIPTION
주문 상품 서비스 테스트를 작성하고, 이를 토대로 서비스를 구현한다.

- 배송 엔티티에 배송 상태 변경 비즈니스 로직을 추가하고, 테스트한다.
- 이와 대응되게 주문 상품 서비스의 배송 상태 변경 로직을 테스트하고, 구현한다.

This closes #66 