### PR TITLE
리팩토링: 에러 메시지 enum 클래스로 모으기

### DIFF
--- a/src/main/java/com/been/onlinestore/common/ErrorMessages.java
+++ b/src/main/java/com/been/onlinestore/common/ErrorMessages.java
@@ -1,0 +1,39 @@
+package com.been.onlinestore.common;
+
+public enum ErrorMessages {
+
+    DUPLICATE_ID("중복 ID 입니다."),
+    ALREADY_SIGNED_UP_USER("이미 가입한 회원입니다."),
+
+    NOT_FOUND_CATEGORY("존재하지 않는 카테고리입니다."),
+    NOT_FOUND_USER("존재하지 않는 회원입니다."),
+    NOT_FOUND_PRODUCT("존재하지 않는 상품입니다."),
+    NOT_FOUND_ADDRESS("존재하지 않는 주소입니다."),
+    NOT_FOUND_CART("존재하지 않는 장바구니입니다."),
+    NOT_FOUND_CART_PRODUCT("존재하지 않는 장바구니 상품입니다."),
+    NOT_FOUND_CART_PRODUCT_IN_CART("장바구니에 해당 상품이 존재하지 않습니다."),
+    NOT_FOUND_ORDER("존재하지 않는 주문입니다."),
+
+    NOT_MATCH_ORDER_PRODUCT_COUNT_TO_QUANTITY_COUNT("입력된 주문 상품의 수와 수량의 수가 맞지 않습니다."),
+    NOT_SALE_PRODUCT("판매하지 않는 상품을 주문하였습니다."),
+    NOT_ENOUGH_STOCK("재고가 부족합니다."),
+
+    FAIL_TO_UPDATE_CATEGORY("카테고리 수정 실패. 카테고리를 수정하는데 필요한 정보를 찾을 수 없습니다."),
+    FAIL_TO_UPDATE_PRODUCT("상품 수정 실패. 상품을 수정하는데 필요한 정보를 찾을 수 없습니다."),
+
+    CANNOT_PREPARING("상품을 준비할 수 없습니다. 결제 완료 단계에서만 상품 준비중 단계로 넘어갈 수 있습니다."),
+    CANNOT_DELIVERING("배송을 시작할 수 없습니다. 상품 준비 중 단계에서만 배송 중 단계로 넘어갈 수 있습니다."),
+    CANNOT_FINAL_DELIVERY("배송을 완료할 수 없습니다. 배송 중 단계에서만 배송 완료 단계로 넘어갈 수 있습니다."),
+    CANNOT_CANCEL_ORDER_PRODUCT("결제 완료 상태인 상품만 취소할 수 있습니다.");
+
+
+    private final String message;
+
+    ErrorMessages(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/been/onlinestore/config/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/been/onlinestore/config/auth/PrincipalDetailsService.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.config.auth;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.controller.dto.security.PrincipalDetails;
 import com.been.onlinestore.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,6 @@ public class PrincipalDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String uid) throws UsernameNotFoundException {
         return userService.searchUser(uid)
                 .map(PrincipalDetails::from)
-                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다 - ID: " + uid));
+                .orElseThrow(() -> new UsernameNotFoundException(ErrorMessages.NOT_FOUND_USER.getMessage()));
     }
 }

--- a/src/main/java/com/been/onlinestore/domain/Delivery.java
+++ b/src/main/java/com/been/onlinestore/domain/Delivery.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.domain;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.constant.DeliveryStatus;
 import lombok.Getter;
 import lombok.ToString;
@@ -53,21 +54,21 @@ public class Delivery {
 
     public void startPreparing() {
         if (this.deliveryStatus != DeliveryStatus.ACCEPT) {
-            throw new IllegalArgumentException("상품 준비 단계로 넘어갈 수 없습니다. 현재 배송 상태 = " + this.deliveryStatus.getDescription());
+            throw new IllegalArgumentException(ErrorMessages.CANNOT_PREPARING.getMessage());
         }
         this.deliveryStatus = DeliveryStatus.PREPARING;
     }
 
     public void startDelivery() {
         if (this.deliveryStatus != DeliveryStatus.PREPARING) {
-            throw new IllegalArgumentException("배송을 시작할 수 없습니다. 현재 배송 상태 = " + this.deliveryStatus.getDescription());
+            throw new IllegalArgumentException(ErrorMessages.CANNOT_DELIVERING.getMessage());
         }
         this.deliveryStatus = DeliveryStatus.DELIVERING;
     }
 
     public void completeDelivery() {
         if (this.deliveryStatus != DeliveryStatus.DELIVERING) {
-            throw new IllegalArgumentException("배송 중이 아닙니다. 현재 배송 상태 = " + this.deliveryStatus.getDescription());
+            throw new IllegalArgumentException(ErrorMessages.CANNOT_FINAL_DELIVERY.getMessage());
         }
         this.deliveryStatus = DeliveryStatus.FINAL_DELIVERY;
         this.deliveredAt = now();

--- a/src/main/java/com/been/onlinestore/domain/OrderProduct.java
+++ b/src/main/java/com/been/onlinestore/domain/OrderProduct.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.domain;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.constant.DeliveryStatus;
 import lombok.Getter;
 import lombok.Setter;
@@ -75,7 +76,7 @@ public class OrderProduct {
 
     public void cancel() {
         if (this.delivery.getDeliveryStatus() != DeliveryStatus.ACCEPT) {
-            throw new IllegalStateException("결제 완료 상태인 상품만 취소할 수 있습니다. 주문 상품 ID = " + id);
+            throw new IllegalStateException(ErrorMessages.CANNOT_CANCEL_ORDER_PRODUCT.getMessage());
         }
         product.addStock(this.quantity);
     }

--- a/src/main/java/com/been/onlinestore/domain/Product.java
+++ b/src/main/java/com/been/onlinestore/domain/Product.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.domain;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.constant.SaleStatus;
 import lombok.Getter;
 import lombok.ToString;
@@ -106,7 +107,7 @@ public class Product extends BaseEntity {
     public void removeStock(int stockQuantity) {
         int restStock = this.stockQuantity - stockQuantity;
         if (restStock < 0) {
-            throw new IllegalArgumentException("재고가 부족합니다. 상품 ID = " + this.id);
+            throw new IllegalArgumentException(ErrorMessages.NOT_ENOUGH_STOCK.getMessage());
         }
         this.stockQuantity = restStock;
     }

--- a/src/main/java/com/been/onlinestore/service/AddressService.java
+++ b/src/main/java/com/been/onlinestore/service/AddressService.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.service;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.Address;
 import com.been.onlinestore.domain.User;
 import com.been.onlinestore.dto.AddressDto;
@@ -9,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,7 +32,7 @@ public class AddressService {
     public AddressDto findAddress(Long addressId, Long userId) {
         return addressRepository.findByIdAndUser_Id(addressId, userId)
                 .map(AddressDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("해당 주소가 존재하지 않습니다. 주소 ID: " + addressId));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_FOUND_ADDRESS.getMessage()));
     }
 
     public Long addAddress(Long userId, AddressDto dto) {
@@ -64,7 +64,7 @@ public class AddressService {
             address.updateInfo(detail, zipcode);
             return addressId;
         } else {
-            throw new IllegalArgumentException("본인의 주소만 수정할 수 있습니다.");
+            throw new IllegalArgumentException(ErrorMessages.NOT_FOUND_ADDRESS.getMessage());
         }
     }
 
@@ -78,7 +78,7 @@ public class AddressService {
             updateDefaultAddress.updateDefaultAddress(true);
             return addressId;
         } else {
-            throw new IllegalArgumentException("본인의 주소만 수정할 수 있습니다.");
+            throw new IllegalArgumentException(ErrorMessages.NOT_FOUND_ADDRESS.getMessage());
         }
     }
 

--- a/src/main/java/com/been/onlinestore/service/CartProductService.java
+++ b/src/main/java/com/been/onlinestore/service/CartProductService.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.service;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.Cart;
 import com.been.onlinestore.domain.CartProduct;
 import com.been.onlinestore.domain.Product;
@@ -27,7 +28,7 @@ public class CartProductService {
     public CartProductDto findCartProduct(Long id) {
         return cartProductRepository.findById(id)
                 .map(CartProductDto::from)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 장바구니 상품입니다."));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_FOUND_CART_PRODUCT.getMessage()));
     }
 
     protected CartProductDto addCartProduct(Cart cart, CartProductDto dto) {
@@ -45,7 +46,7 @@ public class CartProductService {
         validateCartBelongsToUser(cartId, userId);
 
         CartProduct cartProduct = cartProductRepository.findByIdAndCart_Id(cartProductId, cartId)
-                .orElseThrow(() -> new IllegalArgumentException("장바구니에 해당 상품이 존재하지 않습니다. 장바구니 상품 ID = " + cartProductId));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_FOUND_CART_PRODUCT_IN_CART.getMessage()));
 
         cartProduct.updateProductQuantity(updateProductQuantity);
         return CartProductDto.from(cartProduct);
@@ -68,7 +69,7 @@ public class CartProductService {
 
     private void validateCartBelongsToUser(Long cartId, Long userId) {
         if (!isCartExistByUserId(cartId, userId)) {
-            throw new IllegalArgumentException("본인의 장바구니의 상품만 수정할 수 있습니다.");
+            throw new IllegalArgumentException(ErrorMessages.NOT_FOUND_CART.getMessage());
         }
     }
 

--- a/src/main/java/com/been/onlinestore/service/CartService.java
+++ b/src/main/java/com/been/onlinestore/service/CartService.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.service;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.Cart;
 import com.been.onlinestore.domain.User;
 import com.been.onlinestore.dto.CartProductDto;
@@ -41,7 +42,7 @@ public class CartService {
             cartRepository.deleteById(cartId);
             return cartId;
         } else {
-            throw new IllegalArgumentException("본인의 장바구니만 삭제할 수 있습니다.");
+            throw new IllegalArgumentException(ErrorMessages.NOT_FOUND_CART.getMessage());
         }
     }
 

--- a/src/main/java/com/been/onlinestore/service/CategoryService.java
+++ b/src/main/java/com/been/onlinestore/service/CategoryService.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.service;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.Category;
 import com.been.onlinestore.dto.CategoryDto;
 import com.been.onlinestore.repository.CategoryRepository;
@@ -33,7 +34,7 @@ public class CategoryService {
     public CategoryDto findCategory(Long categoryId) {
         return categoryRepository.findWithProductsById(categoryId)
                 .map(CategoryDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("해당 카테고리가 없습니다 - categoryId: " + categoryId));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_FOUND_CATEGORY.getMessage()));
     }
 
     public Long addCategory(CategoryDto dto) {
@@ -55,7 +56,7 @@ public class CategoryService {
             category.updateCategory(name, description);
             return category.getId();
         } catch (EntityNotFoundException e) {
-            log.warn("카테고리 수정 실패. 카테고리를 수정하는데 필요한 정보를 찾을 수 없습니다. - {}", e.getLocalizedMessage());
+            log.warn(ErrorMessages.FAIL_TO_UPDATE_CATEGORY.getMessage());
         }
 
         return null;

--- a/src/main/java/com/been/onlinestore/service/OrderService.java
+++ b/src/main/java/com/been/onlinestore/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.service;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.DeliveryRequest;
 import com.been.onlinestore.domain.Order;
 import com.been.onlinestore.domain.OrderProduct;
@@ -41,7 +42,7 @@ public class OrderService {
     public OrderResponse findOrderByOrderer(Long orderId, Long ordererId) {
         return orderRepository.findOrderByOrderer(orderId, ordererId)
                 .map(OrderResponse::from)
-                .orElseThrow(() -> new IllegalArgumentException("해당 주문을 찾을 수 없습니다. 주문 ID = " + orderId));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_FOUND_ORDER.getMessage()));
     }
 
     @Transactional(readOnly = true)
@@ -54,7 +55,7 @@ public class OrderService {
     public OrderResponse findOrderBySeller(Long orderId, Long sellerId) {
         return orderRepository.findOrderBySeller(orderId, sellerId)
                 .map(OrderResponse::from)
-                .orElseThrow(() -> new IllegalArgumentException("해당 주문을 찾을 수 없습니다. 주문 ID = " + orderId));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_FOUND_ORDER.getMessage()));
     }
 
     public Long order(Long ordererId, List<Long> productIds, List<Integer> quantities, OrderDto dto) {
@@ -64,7 +65,7 @@ public class OrderService {
         List<Product> products = productRepository.findAllOnSaleById(productIdToQuantityMap.keySet());
 
         if (productIdToQuantityMap.keySet().size() != products.size()) {
-            throw new IllegalArgumentException("판매하지 않는 상품을 주문하였습니다.");
+            throw new IllegalArgumentException(ErrorMessages.NOT_SALE_PRODUCT.getMessage());
         }
 
         Map<Product, Integer> productToQuantityMap = convertToProductToQuantityMap(productIdToQuantityMap, products);
@@ -82,14 +83,14 @@ public class OrderService {
 
     public Long cancelOrder(Long orderId, Long ordererId) {
         Order order = orderRepository.findByIdAndOrdererId(orderId, ordererId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 주문을 찾지 못하였습니다. 주문 ID = " + orderId));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_FOUND_ORDER.getMessage()));
         order.cancel();
         return order.getId();
     }
 
     private Map<Long, Integer> makeProductIdToQuantityMap(List<Long> productIds, List<Integer> quantities) {
         if (productIds.size() != quantities.size()) {
-            throw new IllegalArgumentException("입력된 주문 상품의 수와 수량의 수가 맞지 않습니다. 주문 상품 = " + productIds.size() + ", 수량 = " + quantities.size());
+            throw new IllegalArgumentException(ErrorMessages.NOT_MATCH_ORDER_PRODUCT_COUNT_TO_QUANTITY_COUNT.getMessage());
         }
         return IntStream.range(0, productIds.size())
                 .boxed()

--- a/src/main/java/com/been/onlinestore/service/ProductService.java
+++ b/src/main/java/com/been/onlinestore/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.service;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.Category;
 import com.been.onlinestore.domain.Product;
 import com.been.onlinestore.domain.User;
@@ -15,8 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.persistence.EntityNotFoundException;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -45,7 +44,7 @@ public class ProductService {
     public ProductDto findProductInfoOnSale(Long id) {
         return productRepository.findOnSaleById(id)
                 .map(ProductDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("판매 중인 상품 목록에 없습니다. 상품 ID: " + id));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_SALE_PRODUCT.getMessage()));
     }
 
     @Transactional(readOnly = true)
@@ -58,7 +57,7 @@ public class ProductService {
     public ProductDto findProductInfo(Long id) {
         return productRepository.findById(id)
                 .map(ProductDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("상품이 없습니다. 상품 ID: " + id));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_FOUND_PRODUCT.getMessage()));
     }
 
     @Transactional(readOnly = true)
@@ -71,7 +70,7 @@ public class ProductService {
     public ProductDto findProductInfoBySellerId(Long productId, Long sellerId) {
         return productRepository.findByIdAndSeller_Id(productId, sellerId)
                 .map(ProductDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("판매자의 상품 목록에 없습니다. 상품 ID: " + productId));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.NOT_SALE_PRODUCT.getMessage()));
     }
 
     public Long addProduct(Long categoryId, ProductDto dto) {
@@ -106,6 +105,6 @@ public class ProductService {
 
     private Product getProduct(Long productId) {
         return productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("상품 업데이트 실패. 상품을 수정하는데 필요한 정보를 찾을 수 없습니다. 상품 ID = " + productId));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessages.FAIL_TO_UPDATE_PRODUCT.getMessage()));
     }
 }

--- a/src/main/java/com/been/onlinestore/service/UserService.java
+++ b/src/main/java/com/been/onlinestore/service/UserService.java
@@ -1,5 +1,6 @@
 package com.been.onlinestore.service;
 
+import com.been.onlinestore.common.ErrorMessages;
 import com.been.onlinestore.domain.User;
 import com.been.onlinestore.domain.constant.RoleType;
 import com.been.onlinestore.dto.UserDto;
@@ -34,14 +35,14 @@ public class UserService {
     private void validateDuplicateUid(String uid) {
         userRepository.findByUid(uid)
                 .ifPresent(user -> {
-                    throw new IllegalStateException("중복 ID 입니다.");
+                    throw new IllegalStateException(ErrorMessages.DUPLICATE_ID.getMessage());
                 });
     }
 
     private void validateDuplicateEmail(String email) {
         userRepository.findByEmail(email)
                 .ifPresent(user -> {
-                    throw new IllegalStateException("이미 가입한 회원입니다.");
+                    throw new IllegalStateException(ErrorMessages.ALREADY_SIGNED_UP_USER.getMessage());
                 });
     }
 }

--- a/src/test/java/com/been/onlinestore/service/AddressServiceTest.java
+++ b/src/test/java/com/been/onlinestore/service/AddressServiceTest.java
@@ -67,7 +67,7 @@ class AddressServiceTest {
 
     @DisplayName("주소가 없으면, 예외를 던진다.")
     @Test
-    void test_searchAddress_throwsException() {
+    void test_searchAddress_throwsIllegalArgumentException() {
         //Given
         long addressId = 1L;
         long userId = 1L;
@@ -75,7 +75,7 @@ class AddressServiceTest {
 
         //When & Then
         assertThatThrownBy(() -> sut.findAddress(addressId, userId))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(IllegalArgumentException.class);
         then(addressRepository).should().findByIdAndUser_Id(addressId, userId);
     }
 

--- a/src/test/java/com/been/onlinestore/service/ProductServiceTest.java
+++ b/src/test/java/com/been/onlinestore/service/ProductServiceTest.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
-import javax.persistence.EntityNotFoundException;
 import java.util.Optional;
 
 import static com.been.onlinestore.util.CategoryTestDataUtil.createCategory;
@@ -88,14 +87,14 @@ class ProductServiceTest {
 
     @DisplayName("[판매 중인 상품] 상품이 없으면, 예외를 던진다.")
     @Test
-    void test_findProductInfoOnSale_throwsException() {
+    void test_findProductInfoOnSale_throwsIllegalArgumentException() {
         //Given
         long id = 1L;
         given(productRepository.findOnSaleById(id)).willReturn(Optional.empty());
 
         //When & Then
         assertThatThrownBy(() -> sut.findProductInfoOnSale(id))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(IllegalArgumentException.class);
         then(productRepository).should().findOnSaleById(id);
     }
 
@@ -147,14 +146,14 @@ class ProductServiceTest {
 
     @DisplayName("상품이 없으면, 예외를 던진다.")
     @Test
-    void test_findProductInfo_throwsException() {
+    void test_findProductInfo_throwsIllegalArgumentException() {
         //Given
         long id = 1L;
         given(productRepository.findById(id)).willReturn(Optional.empty());
 
         //When & Then
         assertThatThrownBy(() -> sut.findProductInfo(id))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(IllegalArgumentException.class);
         then(productRepository).should().findById(id);
     }
 
@@ -192,7 +191,7 @@ class ProductServiceTest {
 
     @DisplayName("해당 판매자가 판매하지 않는 상품을 조회하면, 예외를 반환한다.")
     @Test
-    void test_findProductInfoBySellerId_throwsException() {
+    void test_findProductInfoBySellerId_throwsIllegalArgumentException() {
         //Given
         long productId = 1L;
         long sellerId = 1L;
@@ -200,7 +199,7 @@ class ProductServiceTest {
 
         //When & Then
         assertThatThrownBy(() -> sut.findProductInfoBySellerId(productId, sellerId))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(IllegalArgumentException.class);
         then(productRepository).should().findByIdAndSeller_Id(productId, sellerId);
     }
 


### PR DESCRIPTION
하드코딩 되어 있던 에러 메시지들을 `ErrorMessages` (enum)으로 모아 관리한다.
그리고 `EntityNotFoundException`을 던지던 메서드들이  `IllegalArgumentException`을 던지도록 수정한다.

This closes #69 