### PR TITLE
리팩토링: 일반 회원 API 엔드포인트 수정

### DIFF
--- a/src/main/java/com/been/onlinestore/config/SecurityConfig.java
+++ b/src/main/java/com/been/onlinestore/config/SecurityConfig.java
@@ -24,6 +24,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
+    private static final String[] WHITE_LIST = {"/", "/api/login", "/api/sign-up", "/api/categories/**", "/api/products/**"};
     private final JwtProperties properties;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -39,11 +40,10 @@ public class SecurityConfig {
                 .and()
                 .authorizeRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        .mvcMatchers("/api/common/**").authenticated()
+                        .mvcMatchers(WHITE_LIST).permitAll()
                         .mvcMatchers("/api/admin/**").hasRole(RoleType.ADMIN.name())
                         .mvcMatchers("/api/seller/**").hasRole(RoleType.SELLER.name())
-                        .mvcMatchers("/api/user/**").hasRole(RoleType.USER.name())
-                        .anyRequest().permitAll()
+                        .mvcMatchers("/api/**").hasRole(RoleType.USER.name())
                 )
                 .logout(logout -> logout.logoutSuccessUrl("/"))
                 .build();

--- a/src/main/java/com/been/onlinestore/controller/user/AddressApiController.java
+++ b/src/main/java/com/been/onlinestore/controller/user/AddressApiController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/user/addresses")
+@RequestMapping("/api/addresses")
 @RestController
 public class AddressApiController {
 

--- a/src/main/java/com/been/onlinestore/controller/user/CartApiController.java
+++ b/src/main/java/com/been/onlinestore/controller/user/CartApiController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/user/carts")
+@RequestMapping("/api/carts")
 @RestController
 public class CartApiController {
 

--- a/src/main/java/com/been/onlinestore/controller/user/OrderApiController.java
+++ b/src/main/java/com/been/onlinestore/controller/user/OrderApiController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/user/orders")
+@RequestMapping("/api/orders")
 @RestController
 public class OrderApiController {
 

--- a/src/main/java/com/been/onlinestore/controller/user/UserApiController.java
+++ b/src/main/java/com/been/onlinestore/controller/user/UserApiController.java
@@ -1,4 +1,4 @@
-package com.been.onlinestore.controller;
+package com.been.onlinestore.controller.user;
 
 import com.been.onlinestore.controller.dto.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -6,9 +6,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/common")
+@RequestMapping("/api/users")
 @RestController
-public class CommonApiController {
+public class UserApiController {
 
     @PutMapping("/info")
     public ResponseEntity<?> updateUserInfo() {

--- a/src/test/java/com/been/onlinestore/controller/user/AddressApiControllerTest.java
+++ b/src/test/java/com/been/onlinestore/controller/user/AddressApiControllerTest.java
@@ -38,7 +38,7 @@ class AddressApiControllerTest {
         //Given
 
         //When & Then
-        mvc.perform(get("/api/user/addresses"))
+        mvc.perform(get("/api/addresses"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -54,7 +54,7 @@ class AddressApiControllerTest {
         //Given
 
         //When & Then
-        mvc.perform(get("/api/user/addresses/" + ID))
+        mvc.perform(get("/api/addresses/" + ID))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -69,7 +69,7 @@ class AddressApiControllerTest {
         //Given
 
         //When & Then
-        mvc.perform(post("/api/user/addresses"))
+        mvc.perform(post("/api/addresses"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -82,7 +82,7 @@ class AddressApiControllerTest {
         //Given
 
         //When & Then
-        mvc.perform(put("/api/user/addresses/" + ID))
+        mvc.perform(put("/api/addresses/" + ID))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -95,7 +95,7 @@ class AddressApiControllerTest {
         //Given
 
         //When & Then
-        mvc.perform(delete("/api/user/addresses/" + ID))
+        mvc.perform(delete("/api/addresses/" + ID))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))

--- a/src/test/java/com/been/onlinestore/controller/user/CartApiControllerTest.java
+++ b/src/test/java/com/been/onlinestore/controller/user/CartApiControllerTest.java
@@ -40,7 +40,7 @@ class CartApiControllerTest {
         //Given
 
         //When & Then
-        mvc.perform(get("/api/user/carts"))
+        mvc.perform(get("/api/carts"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -63,7 +63,7 @@ class CartApiControllerTest {
 
         //When & Then
         mvc.perform(
-                        get("/api/user/carts")
+                        get("/api/carts")
                                 .queryParam("page", String.valueOf(pageNumber))
                                 .queryParam("size", String.valueOf(pageSize))
                                 .queryParam("sort", sortName + "," + direction)
@@ -90,7 +90,7 @@ class CartApiControllerTest {
         long cartProductId = 1L;
 
         //When & Then
-        mvc.perform(post("/api/user/carts"))
+        mvc.perform(post("/api/carts"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -106,7 +106,7 @@ class CartApiControllerTest {
         int productQuantity = 100;
 
         //When & Then
-        mvc.perform(put("/api/user/carts/products/" + cartProductId))
+        mvc.perform(put("/api/carts/products/" + cartProductId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -119,7 +119,7 @@ class CartApiControllerTest {
         //Given
 
         //When & Then
-        mvc.perform(delete("/api/user/carts"))
+        mvc.perform(delete("/api/carts"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))

--- a/src/test/java/com/been/onlinestore/controller/user/OrderApiControllerTest.java
+++ b/src/test/java/com/been/onlinestore/controller/user/OrderApiControllerTest.java
@@ -39,7 +39,7 @@ class OrderApiControllerTest {
         long orderProductId = 1L;
 
         //When & Then
-        mvc.perform(get("/api/user/orders"))
+        mvc.perform(get("/api/orders"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -66,7 +66,7 @@ class OrderApiControllerTest {
 
         //When & Then
         mvc.perform(
-                        get("/api/user/orders")
+                        get("/api/orders")
                                 .queryParam("page", String.valueOf(pageNumber))
                                 .queryParam("size", String.valueOf(pageSize))
                                 .queryParam("sort", sortName + "," + direction)
@@ -95,7 +95,7 @@ class OrderApiControllerTest {
         long orderProductId = 1L;
 
         //When & Then
-        mvc.perform(get("/api/user/orders/" + ORDER_ID))
+        mvc.perform(get("/api/orders/" + ORDER_ID))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -112,7 +112,7 @@ class OrderApiControllerTest {
         //Given
 
         //When & Then
-        mvc.perform(post("/api/user/orders"))
+        mvc.perform(post("/api/orders"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))
@@ -126,7 +126,7 @@ class OrderApiControllerTest {
         OrderStatus orderStatus = OrderStatus.CANCEL;
 
         //When & Then
-        mvc.perform(put("/api/user/orders/" + ORDER_ID + "/cancel"))
+        mvc.perform(put("/api/orders/" + ORDER_ID + "/cancel"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))

--- a/src/test/java/com/been/onlinestore/controller/user/UserApiControllerTest.java
+++ b/src/test/java/com/been/onlinestore/controller/user/UserApiControllerTest.java
@@ -1,4 +1,4 @@
-package com.been.onlinestore.controller;
+package com.been.onlinestore.controller.user;
 
 import com.been.onlinestore.config.SecurityConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Disabled("구현 전")
 @DisplayName("API 컨트롤러 - 회원 (공통)")
 @Import(SecurityConfig.class)
-@WebMvcTest(CommonApiController.class)
-class CommonApiControllerTest {
+@WebMvcTest(UserApiController.class)
+class UserApiControllerTest {
 
     @Autowired private MockMvc mvc;
     @Autowired private ObjectMapper mapper;
@@ -32,7 +32,7 @@ class CommonApiControllerTest {
         long id = 1L;
 
         //When & Then
-        mvc.perform(put("/api/common/info"))
+        mvc.perform(put("/api/users/info"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("success"))


### PR DESCRIPTION
일반 회원이 접근하는 페이지는 메인이기 때문에 `/api/user` -> `/api`로 변경한다.
그리고 회원 정보 수정은 일반 회원만 가능하게 하고 `/api/users/info`로 변경한다.

This closes #73 