### PR TITLE
장바구니 상품 주문 기능 추가

### DIFF
--- a/src/main/java/com/been/onlinestore/controller/CartApiController.java
+++ b/src/main/java/com/been/onlinestore/controller/CartApiController.java
@@ -1,6 +1,7 @@
 package com.been.onlinestore.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -45,6 +46,16 @@ public class CartApiController {
 	) {
 		return ResponseEntity.ok(ApiResponse.success(
 			cartProductService.addCartProduct(principalDetails.id(), request.toServiceRequest())
+		));
+	}
+
+	@PostMapping("/order")
+	public ResponseEntity<ApiResponse<Map<String, Long>>> orderCartProducts(
+		@AuthenticationPrincipal PrincipalDetails principalDetails,
+		@RequestBody @Validated CartProductRequest.Order request
+	) {
+		return ResponseEntity.ok(ApiResponse.successId(
+			cartProductService.order(principalDetails.id(), request.toServiceRequest())
 		));
 	}
 

--- a/src/main/java/com/been/onlinestore/controller/dto/CartProductRequest.java
+++ b/src/main/java/com/been/onlinestore/controller/dto/CartProductRequest.java
@@ -1,8 +1,13 @@
 package com.been.onlinestore.controller.dto;
 
+import java.util.List;
+
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
 
 import com.been.onlinestore.service.dto.request.CartProductServiceRequest;
 
@@ -20,6 +25,34 @@ public record CartProductRequest() {
 			return CartProductServiceRequest.Create.of(
 				productId,
 				productQuantity
+			);
+		}
+	}
+
+	public record Order(
+		@NotNull
+		List<@Positive Long> cartProductIds,
+
+		@NotEmpty
+		@Size(max = 50)
+		String deliveryAddress,
+
+		@NotEmpty
+		@Size(max = 20)
+		String receiverName,
+
+		@NotEmpty
+		@Size(max = 20)
+		@Pattern(regexp = "^010([0-9]{7,8})+$", message = "'-'(하이픈) 없이 10 ~ 11 자리의 숫자만 입력 가능합니다.")
+		String receiverPhone
+	) {
+
+		public CartProductServiceRequest.Order toServiceRequest() {
+			return CartProductServiceRequest.Order.of(
+				cartProductIds,
+				deliveryAddress,
+				receiverName,
+				receiverPhone
 			);
 		}
 	}

--- a/src/main/java/com/been/onlinestore/controller/dto/OrderRequest.java
+++ b/src/main/java/com/been/onlinestore/controller/dto/OrderRequest.java
@@ -1,9 +1,5 @@
 package com.been.onlinestore.controller.dto;
 
-import static com.been.onlinestore.service.dto.request.OrderServiceRequest.*;
-
-import java.util.List;
-
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -14,7 +10,12 @@ import com.been.onlinestore.service.dto.request.OrderServiceRequest;
 
 public record OrderRequest(
 	@NotNull
-	List<OrderProductRequest> orderProducts,
+	@Positive
+	Long productId,
+
+	@NotNull
+	@Positive(message = "한 개 이상의 상품을 주문해주세요.")
+	Integer quantity,
 
 	@NotEmpty
 	@Size(max = 50)
@@ -32,27 +33,11 @@ public record OrderRequest(
 
 	public OrderServiceRequest toServiceRequest() {
 		return OrderServiceRequest.of(
-			orderProducts.stream()
-				.map(OrderProductRequest::toServiceRequest)
-				.toList(),
+			productId,
+			quantity,
 			deliveryAddress,
 			receiverName,
 			receiverPhone
 		);
-	}
-
-	public record OrderProductRequest(
-		@NotNull
-		@Positive
-		Long id,
-
-		@NotNull
-		@Positive(message = "한 개 이상의 상품을 주문해주세요.")
-		Integer quantity
-	) {
-
-		public OrderProductServiceRequest toServiceRequest() {
-			return OrderProductServiceRequest.of(id, quantity);
-		}
 	}
 }

--- a/src/main/java/com/been/onlinestore/domain/Order.java
+++ b/src/main/java/com/been/onlinestore/domain/Order.java
@@ -25,7 +25,6 @@ import com.been.onlinestore.domain.constant.DeliveryStatus;
 import com.been.onlinestore.domain.constant.OrderStatus;
 
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 @Getter
@@ -51,7 +50,6 @@ public class Order extends BaseTimeEntity {
 	private Delivery delivery;
 
 	@ToString.Exclude
-	@Setter
 	@OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST)
 	private List<OrderProduct> orderProducts = new ArrayList<>();
 
@@ -83,7 +81,7 @@ public class Order extends BaseTimeEntity {
 		return new Order(orderer, deliveryRequest, delivery, ordererPhone, orderStatus);
 	}
 
-	public void addOrderProducts(List<OrderProduct> orderProducts) {
+	public void setOrderProducts(List<OrderProduct> orderProducts) {
 		this.orderProducts = orderProducts;
 		orderProducts.forEach(orderProduct -> orderProduct.setOrder(this));
 	}

--- a/src/main/java/com/been/onlinestore/repository/CartProductRepository.java
+++ b/src/main/java/com/been/onlinestore/repository/CartProductRepository.java
@@ -31,6 +31,14 @@ public interface CartProductRepository extends JpaRepository<CartProduct, Long> 
 	@Query("select cp from CartProduct cp "
 		+ "join fetch cp.product p "
 		+ "join fetch cp.user u "
+		+ "where cp.id in :cartProductIds and u.id = :userId")
+	List<CartProduct> findCartProducts(
+		@Param("userId") Long userId, @Param("cartProductIds") List<Long> cartProductIds
+	);
+
+	@Query("select cp from CartProduct cp "
+		+ "join fetch cp.product p "
+		+ "join fetch cp.user u "
 		+ "where cp.id = :cartProductId and u.id = :userId")
 	Optional<CartProduct> findCartProduct(@Param("userId") Long userId, @Param("cartProductId") Long cartProductId);
 

--- a/src/main/java/com/been/onlinestore/service/dto/request/CartProductServiceRequest.java
+++ b/src/main/java/com/been/onlinestore/service/dto/request/CartProductServiceRequest.java
@@ -1,5 +1,7 @@
 package com.been.onlinestore.service.dto.request;
 
+import java.util.List;
+
 import com.been.onlinestore.domain.CartProduct;
 import com.been.onlinestore.domain.Product;
 import com.been.onlinestore.domain.User;
@@ -14,6 +16,20 @@ public record CartProductServiceRequest() {
 
 		public CartProduct toEntity(User user, Product product) {
 			return CartProduct.of(user, product, productQuantity);
+		}
+	}
+
+	public record Order(
+		List<Long> cartProductIds,
+		String deliveryAddress,
+		String receiverName,
+		String receiverPhone
+	) {
+
+		public static Order of(
+			List<Long> cartProductIds, String deliveryAddress, String receiverName, String receiverPhone
+		) {
+			return new Order(cartProductIds, deliveryAddress, receiverName, receiverPhone);
 		}
 	}
 }

--- a/src/main/java/com/been/onlinestore/service/dto/request/OrderServiceRequest.java
+++ b/src/main/java/com/been/onlinestore/service/dto/request/OrderServiceRequest.java
@@ -1,34 +1,16 @@
 package com.been.onlinestore.service.dto.request;
 
-import java.util.List;
-
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-
 public record OrderServiceRequest(
-	List<OrderProductServiceRequest> orderProducts,
+	Long productId,
+	Integer quantity,
 	String deliveryAddress,
 	String receiverName,
 	String receiverPhone
 ) {
 
 	public static OrderServiceRequest of(
-		List<OrderProductServiceRequest> orderProducts,
-		String deliveryAddress, String receiverName, String receiverPhone
+		Long productId, Integer quantity, String deliveryAddress, String receiverName, String receiverPhone
 	) {
-		return new OrderServiceRequest(orderProducts, deliveryAddress, receiverName, receiverPhone);
-	}
-
-	public record OrderProductServiceRequest(
-		@NotNull @Positive
-		Long id,
-
-		@NotNull @Positive(message = "한 개 이상의 상품을 주문해주세요.")
-		Integer quantity
-	) {
-
-		public static OrderProductServiceRequest of(Long id, Integer quantity) {
-			return new OrderProductServiceRequest(id, quantity);
-		}
+		return new OrderServiceRequest(productId, quantity, deliveryAddress, receiverName, receiverPhone);
 	}
 }

--- a/src/main/java/com/been/onlinestore/service/dto/response/CartProductResponse.java
+++ b/src/main/java/com/been/onlinestore/service/dto/response/CartProductResponse.java
@@ -4,7 +4,7 @@ import com.been.onlinestore.domain.CartProduct;
 import com.been.onlinestore.domain.Product;
 
 public record CartProductResponse(
-	Long productId,
+	Long cartProductId,
 	String productName,
 	int productPrice,
 	int quantity,
@@ -12,9 +12,9 @@ public record CartProductResponse(
 ) {
 
 	public static CartProductResponse of(
-		Long productId, String productName, int productPrice, int quantity, int totalPrice
+		Long cartProductId, String productName, int productPrice, int quantity, int totalPrice
 	) {
-		return new CartProductResponse(productId, productName, productPrice, quantity, totalPrice);
+		return new CartProductResponse(cartProductId, productName, productPrice, quantity, totalPrice);
 	}
 
 	public static CartProductResponse from(CartProduct entity) {

--- a/src/test/java/com/been/onlinestore/controller/CartApiControllerTest.java
+++ b/src/test/java/com/been/onlinestore/controller/CartApiControllerTest.java
@@ -72,7 +72,7 @@ class CartApiControllerTest extends RestDocsSupport {
 			.andExpect(jsonPath("$.data.totalPrice").value(response.totalPrice()))
 			.andExpect(jsonPath("$.data.deliveryFee").value(response.deliveryFee()))
 			.andExpect(jsonPath("$.data.cartProducts").isArray())
-			.andExpect(jsonPath("$.data.cartProducts[0].productId").value(cartProductResponse1.productId()))
+			.andExpect(jsonPath("$.data.cartProducts[0].cartProductId").value(cartProductResponse1.cartProductId()))
 			.andExpect(jsonPath("$.data.cartProducts[0].productName").value(cartProductResponse1.productName()))
 			.andExpect(jsonPath("$.data.cartProducts[0].quantity").value(cartProductResponse1.quantity()))
 			.andDo(document(
@@ -86,8 +86,8 @@ class CartApiControllerTest extends RestDocsSupport {
 						.description(CART_TOTAL_PRICE.getDescription()),
 					fieldWithPath("data.deliveryFee").type(JsonFieldType.NUMBER)
 						.description(DELIVERY_FEE.getDescription()),
-					fieldWithPath("data.cartProducts[].productId").type(JsonFieldType.NUMBER)
-						.description(PRODUCT_ID.getDescription()),
+					fieldWithPath("data.cartProducts[].cartProductId").type(JsonFieldType.NUMBER)
+						.description(CART_PRODUCT_ID.getDescription()),
 					fieldWithPath("data.cartProducts[].productName").type(JsonFieldType.STRING)
 						.description(PRODUCT_NAME.getDescription()),
 					fieldWithPath("data.cartProducts[].productPrice").type(JsonFieldType.NUMBER)
@@ -131,7 +131,7 @@ class CartApiControllerTest extends RestDocsSupport {
 			.andExpect(status().isOk())
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.status").value("success"))
-			.andExpect(jsonPath("$.data.productId").value(response.productId()))
+			.andExpect(jsonPath("$.data.cartProductId").value(response.cartProductId()))
 			.andExpect(jsonPath("$.data.quantity").value(response.quantity()))
 			.andDo(document(
 				"user/cart/addProductToCart",
@@ -146,8 +146,8 @@ class CartApiControllerTest extends RestDocsSupport {
 				),
 				responseFields(
 					STATUS,
-					fieldWithPath("data.productId").type(JsonFieldType.NUMBER)
-						.description(PRODUCT_ID.getDescription()),
+					fieldWithPath("data.cartProductId").type(JsonFieldType.NUMBER)
+						.description(CART_PRODUCT_ID.getDescription()),
 					fieldWithPath("data.productName").type(JsonFieldType.STRING)
 						.description(PRODUCT_NAME.getDescription()),
 					fieldWithPath("data.productPrice").type(JsonFieldType.NUMBER)
@@ -191,7 +191,7 @@ class CartApiControllerTest extends RestDocsSupport {
 			.andExpect(status().isOk())
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.status").value("success"))
-			.andExpect(jsonPath("$.data.productId").value(response.productId()))
+			.andExpect(jsonPath("$.data.cartProductId").value(response.cartProductId()))
 			.andExpect(jsonPath("$.data.quantity").value(response.quantity()))
 			.andDo(document(
 				"user/cart/updateProductInCart",
@@ -206,8 +206,8 @@ class CartApiControllerTest extends RestDocsSupport {
 				),
 				responseFields(
 					STATUS,
-					fieldWithPath("data.productId").type(JsonFieldType.NUMBER)
-						.description(PRODUCT_ID.getDescription()),
+					fieldWithPath("data.cartProductId").type(JsonFieldType.NUMBER)
+						.description(CART_PRODUCT_ID.getDescription()),
 					fieldWithPath("data.productName").type(JsonFieldType.STRING)
 						.description(PRODUCT_NAME.getDescription()),
 					fieldWithPath("data.productPrice").type(JsonFieldType.NUMBER)

--- a/src/test/java/com/been/onlinestore/controller/OrderApiControllerTest.java
+++ b/src/test/java/com/been/onlinestore/controller/OrderApiControllerTest.java
@@ -1,6 +1,5 @@
 package com.been.onlinestore.controller;
 
-import static com.been.onlinestore.controller.dto.OrderRequest.*;
 import static com.been.onlinestore.controller.restdocs.FieldDescription.*;
 import static com.been.onlinestore.controller.restdocs.RestDocsUtils.*;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
@@ -278,8 +277,7 @@ class OrderApiControllerTest extends RestDocsSupport {
 		//Given
 		long orderId = 1L;
 		long userId = TestSecurityConfig.USER_ID;
-		OrderProductRequest orderProductRequest = new OrderProductRequest(1L, 10);
-		OrderRequest request = new OrderRequest(List.of(orderProductRequest), "서울 종로구 청와대로 1", "user", "01011112222");
+		OrderRequest request = new OrderRequest(1L, 10, "서울 종로구 청와대로 1", "user", "01011112222");
 
 		given(orderService.order(userId, request.toServiceRequest())).willReturn(orderId);
 
@@ -297,12 +295,14 @@ class OrderApiControllerTest extends RestDocsSupport {
 			.andExpect(jsonPath("$.data.id").value(orderId))
 			.andDo(document(
 				"user/order/order",
-				userApiDescription(TagDescription.ORDER, "주문하기"),
+				userApiDescription(TagDescription.ORDER, "주문하기 (바로 구매)"),
 				preprocessRequest(prettyPrint()),
 				preprocessResponse(prettyPrint()),
 				requestFields(
-					subsectionWithPath("orderProducts").type(JsonFieldType.ARRAY)
-						.description("주문 상품"),
+					fieldWithPath("productId").type(JsonFieldType.NUMBER)
+						.description(PRODUCT_ID.getDescription()),
+					fieldWithPath("quantity").type(JsonFieldType.NUMBER)
+						.description(ORDER_PRODUCT_QUANTITY.getDescription()),
 					fieldWithPath("deliveryAddress").type(JsonFieldType.STRING)
 						.description(DELIVERY_REQUEST_ADDRESS.getDescription()),
 					fieldWithPath("receiverName").type(JsonFieldType.STRING)


### PR DESCRIPTION
장바구니에서 상품을 선택해서 주문하는 기능(`/api/carts/order`)을 추가한다.
기존의 주문 기능(`/api/orders`)은 상품을 장바구니에 넣지 않고 바로 구매할 때 사용한다.

This closes #155 