### PR TITLE
openapi3 설정 오타 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ swaggerSources {
 
 openapi3 {
     if ("${profile}" == 'prod') {
-        server = 'http://onlinesstoreapi.kro.kr'
+        server = 'http://onlinestoreapi.kro.kr'
     } else {
         server = 'http://localhost:8080'
     }


### PR DESCRIPTION
`server`의 오타를 수정한다.

This closes #173 